### PR TITLE
gitignoreの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Created by https://www.gitignore.io/api/gitbook
+# Edit at https://www.gitignore.io/?templates=gitbook
+
+### GitBook ###
+# Node rules:
+## Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+## Dependency directory
+## Commenting this out is preferred by some people, see
+## https://docs.npmjs.com/misc/faq#should-i-check-my-node_modules-folder-into-git
+node_modules
+
+# Book build output
+_book
+
+# eBook build output
+*.epub
+*.mobi
+*.pdf
+
+# End of https://www.gitignore.io/api/gitbook


### PR DESCRIPTION
gitignoreを追加  
初期として`gitbook`関連のignore設定を[gitignore.io](https://www.gitignore.io/)から生成して追記