### PR TITLE
Feature/7/introduce toc plugin for gitbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ gibook
 
     $ git clone https://github.com/amenoci/poppin
 
-### ドキュメント
+### ドキュメント開発環境の導入
 pluginのインストール
 
     $ cd poppin/
     $ gitbook install docs/
 
 ## Usage
-### ドキュメント
+### ドキュメント開発
 ドキュメントサーバの起動
 
     $ cd poppin/

--- a/docs/book.json
+++ b/docs/book.json
@@ -1,5 +1,6 @@
 {
     "plugins": [
-        "include"
+        "include",
+        "etoc-plus"
     ]
 }


### PR DESCRIPTION
#7 の対応

issueにも記載の通り、https://github.com/JustPilz/gitbook-plugin-etoc-plus を導入する  
このpluginは対象のマークダウンのファイルに特に何も追記しなくても、pluginをインストールするだけで目次が追加される
> This plugin will add table of content (toc) to the page automatically. When you build the book, it will insert a table of content automatically 

明示的に`<!-- toc -->`を追加すればその箇所をreplaceする形で目次が挿入されるようである
> or to place where you insert \<!-- toc --\>

また、目次が不要な場合は`<!-- notoc -->`を明示的に入れなければならないようである
> Sometimes you may want to disable toc on some page, just add \<!-- notoc --\> on the the markdown page.


このpluginの導入に伴い、READMEの見出しの文言を修正  
これは、markdownのページ内リンクが同一文言の見出しについては先頭にあるものだけ有効となる挙動のため、目次を有効かするために修正したものである